### PR TITLE
feat: post page ui 구현

### DIFF
--- a/src/app/posts/[category]/layout.tsx
+++ b/src/app/posts/[category]/layout.tsx
@@ -1,0 +1,10 @@
+import PostSideBar from "@/components/post/PostSideBar";
+
+export default function PostsCategoryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="posts-area flex gap-6">
+      <PostSideBar />
+      {children}
+    </div>
+  );
+}

--- a/src/app/posts/[category]/page.tsx
+++ b/src/app/posts/[category]/page.tsx
@@ -1,0 +1,4 @@
+export default async function PostsCategoryPage() {
+  // 카테고리 선택 관련 로직 작성 예정
+  return null;
+}

--- a/src/app/posts/[category]/post/[postId]/page.tsx
+++ b/src/app/posts/[category]/post/[postId]/page.tsx
@@ -1,0 +1,20 @@
+import ResponsiveContainer from "@/components/common/ResponsiveContainer";
+import MessageBubble from "@/components/MessageBubble";
+import PostCard from "@/components/post/PostCard";
+
+export default async function PostPage({ params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return (
+    <>
+      <ResponsiveContainer className="bg-bg-sub w-full">
+        <PostCard
+          userName="나"
+          title="이거 썸 맞나요?"
+          content="이거 썸 맞나요?"
+          className="bg-bg-main border-t-0 border-r-0 border-l-0"
+        />
+        <MessageBubble time="오전 10:30" text="안녕하세요 반가워요" />
+      </ResponsiveContainer>
+    </>
+  );
+}

--- a/src/app/posts/layout.tsx
+++ b/src/app/posts/layout.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import BaseImage from "@/components/common/image/BaseImage";
+
+export default function PostsLayout({ children }: { children: React.ReactNode }) {
+  // 테스트용 변수
+  const categorys = new Array(11).fill(null);
+  let key = 0;
+
+  return (
+    <div className="flex w-full flex-col p-6">
+      <div className="category mb-6 flex gap-6">
+        <Link href={"/posts/all"}>
+          {" "}
+          <div className="bg-bg-main border-main text-main flex h-15 w-15 items-center justify-center rounded-full border">
+            전체
+          </div>
+        </Link>
+        {categorys.map(() => (
+          <Link key={key++} href={"/posts/"}>
+            <BaseImage rounded="full" src="/" alt="category image" className="h-15 w-15" />
+          </Link>
+        ))}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,0 +1,8 @@
+// app/posts/page.tsx
+import { redirect } from "next/navigation";
+
+export default function PostsPage() {
+  // 카테고리 기본값 = 전체 보기 (all)
+  // .../posts 경로로 접근시 리다이렉트
+  redirect("/posts/all");
+}

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,4 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
 
 const BadgeVariants = cva("w-max h-max rounded-sm", {
   variants: {
@@ -16,17 +17,14 @@ const BadgeVariants = cva("w-max h-max rounded-sm", {
 });
 
 interface BadgeProps extends VariantProps<typeof BadgeVariants> {
-  bgColor: string;
-  textColor: string;
   text: string;
+  className?: string;
 }
 
-export default function Badge({ size, bgColor, textColor, text }: BadgeProps) {
+export default function Badge({ size, text, className }: BadgeProps) {
   return (
     <>
-      <div style={{ backgroundColor: bgColor, color: textColor }} className={BadgeVariants({ size })}>
-        {text}
-      </div>
+      <div className={twMerge(BadgeVariants({ size }), className)}>{text}</div>
     </>
   );
 }

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -1,17 +1,18 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { Heart, MessageSquareMore, Share2 } from "lucide-react";
+import { BookMarked, Heart, MessageSquareMore, Share2 } from "lucide-react";
 import Image from "next/image";
+import { twMerge } from "tailwind-merge";
 import Badge from "../common/Badge";
 
 const containerVariants = cva("post-card flex flex-col rounded-3xl border border-gray-200 px-6 py-5", {
   variants: {
     device: {
-      pc: "w-[518px]",
-      mobile: "w-[320px]",
+      pc: "min-w-[518px]",
+      mobile: "min-w-[320px]",
     },
-    defaultVariants: {
-      device: "pc",
-    },
+  },
+  defaultVariants: {
+    device: "pc",
   },
 });
 
@@ -20,12 +21,12 @@ const thumbnailVariants = cva(
   {
     variants: {
       device: {
-        pc: "w-[470px] h-[196px]",
-        mobile: "w-[272px] h-[113px]",
+        pc: "min-w-[470px] h-[196px]",
+        mobile: "min-w-[272px] h-[113px]",
       },
-      defaultVariants: {
-        device: "pc",
-      },
+    },
+    defaultVariants: {
+      device: "pc",
     },
   }
 );
@@ -34,12 +35,13 @@ interface PostCardProps extends VariantProps<typeof containerVariants> {
   userName: string;
   title: string;
   content: string;
+  className?: string;
 }
 
-export default function PostCard({ device, userName, title, content }: PostCardProps) {
+export default function PostCard({ device, userName, title, content, className }: PostCardProps) {
   return (
     <>
-      <div className={containerVariants({ device })}>
+      <div className={twMerge(containerVariants({ device }), className)}>
         <div className="post-card_user mb-7.5 flex items-center justify-between">
           <div className="post-card_user-info text-text-title flex items-center">
             <Image
@@ -49,30 +51,26 @@ export default function PostCard({ device, userName, title, content }: PostCardP
               height={32}
               className="rounded-sm border border-gray-200"
             />
-            <span className="mr-2 ml-5 text-xs">userName</span>
-            <Badge size="sm" bgColor="#CAD5E2" textColor="#000000" text="칭호칭호" />
+            <span className="mr-2 ml-5 text-xs">{userName}</span>
+            <Badge size="sm" text="칭호칭호" className="bg-gray-200 text-black" />
           </div>
           <button className="hover:bg-main-50 flex h-max cursor-pointer items-center justify-center rounded-lg p-2">
             <span className="text-main text-[8px]">팔로우</span>
           </button>
         </div>
         <div className="post-card_detail flex flex-col gap-3">
-          <p className="post-card_post-title text-text-title text-base">제목</p>
-          <p className="post-card_post-content text-text-sub text-sm">내용</p>
+          <p className="post-card_post-title text-text-title text-base font-bold">{title}</p>
+          <p className="post-card_post-content text-text-sub text-sm">{content}</p>
           <div className={thumbnailVariants({ device })}>
             <Image src="/post_thumbnail_sample.jpg" alt="post thumbnail image" fill className="object-cover" />
           </div>
           <div className="post-card_btns text-text-sub flex gap-6">
-            <div className="post-card_like flex items-center justify-center">
-              <Heart size={12} />
-              <span className="ml-2 text-xs">1</span>
-            </div>
             <div className="post-card_comment flex items-center justify-center">
               <MessageSquareMore size={12} />
               <span className="ml-2 text-xs">1</span>
             </div>
             <div className="post-card_share flex items-center justify-center">
-              <Share2 size={12} />
+              <BookMarked size={12} />
               <span className="ml-2 text-xs">1</span>
             </div>
           </div>

--- a/src/components/post/PostCardButton.tsx
+++ b/src/components/post/PostCardButton.tsx
@@ -2,6 +2,7 @@
 
 import { cva, VariantProps } from "class-variance-authority";
 import { ChevronRight } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
 import PostCardBookMark from "./PostCardBookMark";
@@ -15,14 +16,14 @@ const containerVariants = cva(
         pc: "w-[244px]",
         mobile: "w-[190px]",
       },
-      defaultVariants: {
-        device: "pc",
-      },
+    },
+    defaultVariants: {
+      device: "pc",
     },
   }
 );
 
-const userTextVariants = cva("post-card-btn_user", {
+const userTextVariants = cva("post-card-btn_user flex justify-start", {
   variants: {
     device: {
       pc: "text-xs",
@@ -41,18 +42,30 @@ const titleVariants = cva("post-card-btn_title", {
 });
 
 interface PostCardButtonProps extends VariantProps<typeof containerVariants> {
+  categoryId: string;
+  postId: string;
   userName: string;
   title: string;
   date: string;
+  className?: string;
 }
 
-export default function PostCardButton({ device, userName, title, date }: PostCardButtonProps) {
+export default function PostCardButton({
+  device,
+  categoryId,
+  postId,
+  userName,
+  title,
+  date,
+  className,
+}: PostCardButtonProps) {
   const [isClicked, setIsClicked] = useState(false);
 
   return (
     <>
-      <button
-        className={twMerge(containerVariants({ device }), isClicked && "bg-main-50")}
+      <Link
+        href={`/posts/${categoryId}/post/${postId}`}
+        className={twMerge(containerVariants({ device }), className, isClicked && "bg-main-50")}
         onClick={() => setIsClicked(prev => !prev)}
       >
         <div className="post-card-btn_info space-y-2.5">
@@ -62,12 +75,12 @@ export default function PostCardButton({ device, userName, title, date }: PostCa
             <span className="text-text-light">{date}</span>
           </div>
           <p className={titleVariants({ device })}>{title}</p>
-          <Badge size="xs" bgColor="#ED7371" textColor="#FFFFFF" text="카테고리" />
+          <Badge size="xs" text="카테고리" className="bg-rose-400 text-white" />
         </div>
         <div className="post-card-btn_detail-btn text-text-sub my-auto w-4.5">
           <ChevronRight size={18} />
         </div>
-      </button>
+      </Link>
     </>
   );
 }

--- a/src/components/post/PostSideBar.tsx
+++ b/src/components/post/PostSideBar.tsx
@@ -1,0 +1,31 @@
+import { Grid2x2, Plus, Users } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Divider } from "@/components/common/Divider";
+import ResponsiveContainer from "@/components/common/ResponsiveContainer";
+import PostCardButton from "@/components/post/PostCardButton";
+
+export default function PostSideBar() {
+  return (
+    <div className="category-side flex max-w-[270px] flex-col items-center justify-center gap-2">
+      <Button size="md" className="w-60">
+        <Plus size={24} />
+        <span>글쓰기</span>
+      </Button>
+      <Divider width="90" />
+      <div className="post-filter-btn flex gap-3">
+        <Button size="sm">
+          <Grid2x2 size={12} className="mr-2" />
+          <span>전체보기</span>
+        </Button>
+        <Button size="sm" className="px-3" variant="tertiary">
+          <Users size={12} className="mr-2" />
+          <span>내가 팔로우한 사용자</span>
+        </Button>
+      </div>
+      <ResponsiveContainer className="px-3 py-4.5">
+        <PostCardButton categoryId="all" postId="1" userName="김철수" title="이거 썸 맞나요?" date="5일 전" />
+        <PostCardButton categoryId="all" postId="1" userName="김철수" title="이거 썸 맞나요?" date="5일 전" />
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📖 개요

> **post 페이지 ui 구현**

- post 페이지는 총 3가지 경로를 가집니다
  - posts
  - posts/[category]
  - posts/[category]/post/[postId]
- posts
  - 카테고리를 선택할 수 있는 경로로, 카테고리의 기본값은 all이기 때문에 접근 시 posts/all로 리다이렉트 됩니다.
- posts/[category]
  - 카테고리에 해당되는 게시글들이 필터되고(필터 기능은 구현 전), 각 게시글 버튼을 눌러 게시글 상세 페이지로 이동할 수 있습니다.
- posts/[category]/post/[postId]
  - postId에 해당되는 게시글의 상세 페이지입니다.

> **Badge, PostCard, PostCardButton 컴포넌트 리팩토링**

- 확장성을 위해 props에 추가적으로 className을 받도록 수정했습니다.
- defaultVariants 객체가 잘못된 위치에 작성되어 있던 걸 수정했습니다.
- 이전에 논의한 내용대로 PostCard의 좋아요 부분을 삭제하고 공유 → 북마크로 수정했습니다.

## ✅ 관련 이슈

- Close #32

## 🛠️ 상세 작업 내용

- [x] posts 페이지 ui 구현
- [x] posts/[category] 페이지 ui 구현
- [x] posts/[category]/post/[postId] 페이지 ui 구현
- [x] Badge, PostCard, PostCardButton 컴포넌트 리팩토링

## 👥 리뷰 확인 사항 (옵션)

- 아직 상태나 라우팅 등의 기능적인 부분은 구현 전입니다! ui만 봐주시면 감사하겠습니다.
- 일단 반응형은 고려하지 않고 pc 기준으로만 작성했습니다.