### PR TITLE
feat: 카테고리별 라우팅 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,16 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lfkxloulmqeonuzaudtt.supabase.co",
+        port: "",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/posts/layout.tsx
+++ b/src/app/posts/layout.tsx
@@ -1,27 +1,16 @@
-import Link from "next/link";
-import BaseImage from "@/components/common/image/BaseImage";
+import Category from "@/components/post/Category";
+import { createClient } from "@/utils/supabase/client";
 
-export default function PostsLayout({ children }: { children: React.ReactNode }) {
-  // 테스트용 변수
-  const categorys = new Array(11).fill(null);
-  let key = 0;
+export default async function PostsLayout({ children }: { children: React.ReactNode }) {
+  const supabase = createClient();
+  const { data } = await supabase.from("category").select("*");
 
-  return (
-    <div className="flex w-full flex-col p-6">
-      <div className="category mb-6 flex gap-6">
-        <Link href={"/posts/all"}>
-          {" "}
-          <div className="bg-bg-main border-main text-main flex h-15 w-15 items-center justify-center rounded-full border">
-            전체
-          </div>
-        </Link>
-        {categorys.map(() => (
-          <Link key={key++} href={"/posts/"}>
-            <BaseImage rounded="full" src="/" alt="category image" className="h-15 w-15" />
-          </Link>
-        ))}
+  if (data) {
+    return (
+      <div className="flex w-full flex-col p-6">
+        <Category categorys={data} />
+        <div>{children}</div>
       </div>
-      <div>{children}</div>
-    </div>
-  );
+    );
+  } else return null;
 }

--- a/src/components/post/Category.tsx
+++ b/src/components/post/Category.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { twMerge } from "tailwind-merge";
+import { CategoryType } from "@/types";
+import BaseImage from "../common/image/BaseImage";
+
+export default function Category({ categorys }: { categorys: CategoryType[] }) {
+  const pathname = usePathname();
+  const currentCategory = pathname.split("/")[2];
+
+  return (
+    <div className="category mb-6 flex gap-6">
+      <Link href={"/posts/all"}>
+        {" "}
+        <div
+          className={twMerge(
+            `bg-bg-main text-main border-text-light hover:bg-bg-sub flex h-15 w-15 items-center justify-center rounded-full border text-xs transition-all duration-300`,
+            currentCategory === "all" && "border-main border-2"
+          )}
+        >
+          전체
+        </div>
+      </Link>
+      {categorys.map(category => (
+        <Link key={category.id} href={`/posts/${category.type}`} className="group relative">
+          <BaseImage
+            rounded="full"
+            src={category.image_url ?? ""}
+            alt={`category ${category.name} image`}
+            className={twMerge(
+              `h-15 w-15 transition-all duration-300 group-hover:opacity-30`,
+              currentCategory === category.type && "border-main border-2"
+            )}
+          />
+          <span
+            className={twMerge(
+              `invisible absolute top-1/2 left-1/2 w-full -translate-x-1/2 -translate-y-1/2 truncate text-center text-xs group-hover:visible`
+            )}
+          >
+            {category.name}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,3 @@
+import { Database } from "@/utils/supabase/supabase";
+
+export type CategoryType = Database["public"]["Tables"]["category"]["Row"];

--- a/src/utils/supabase/supabase.ts
+++ b/src/utils/supabase/supabase.ts
@@ -1,0 +1,519 @@
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "13.0.5";
+  };
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+  public: {
+    Tables: {
+      badge: {
+        Row: {
+          badge_image: string | null;
+          category_id: string;
+          desc: string;
+          id: string;
+          name: string;
+          point: number | null;
+        };
+        Insert: {
+          badge_image?: string | null;
+          category_id: string;
+          desc: string;
+          id?: string;
+          name: string;
+          point?: number | null;
+        };
+        Update: {
+          badge_image?: string | null;
+          category_id?: string;
+          desc?: string;
+          id?: string;
+          name?: string;
+          point?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "badge_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "category";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      bookmark: {
+        Row: {
+          created_at: string;
+          id: string;
+          post_id: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          post_id: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          post_id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "bookmark_post_id_fkey";
+            columns: ["post_id"];
+            isOneToOne: false;
+            referencedRelation: "posts";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "bookmark_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      category: {
+        Row: {
+          id: string;
+          image_url: string | null;
+          name: string;
+          type: string | null;
+        };
+        Insert: {
+          id?: string;
+          image_url?: string | null;
+          name: string;
+          type?: string | null;
+        };
+        Update: {
+          id?: string;
+          image_url?: string | null;
+          name?: string;
+          type?: string | null;
+        };
+        Relationships: [];
+      };
+      comment_reactions: {
+        Row: {
+          comment_id: string;
+          created_at: string;
+          id: string;
+          type: string;
+          user_id: string;
+        };
+        Insert: {
+          comment_id: string;
+          created_at?: string;
+          id?: string;
+          type: string;
+          user_id: string;
+        };
+        Update: {
+          comment_id?: string;
+          created_at?: string;
+          id?: string;
+          type?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "comment_reactions_comment_id_fkey";
+            columns: ["comment_id"];
+            isOneToOne: false;
+            referencedRelation: "comments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "comment_reactions_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      comments: {
+        Row: {
+          content: string;
+          created_at: string;
+          id: string;
+          post_id: string;
+          user_id: string;
+        };
+        Insert: {
+          content: string;
+          created_at?: string;
+          id?: string;
+          post_id: string;
+          user_id: string;
+        };
+        Update: {
+          content?: string;
+          created_at?: string;
+          id?: string;
+          post_id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "comments_post_id_fkey";
+            columns: ["post_id"];
+            isOneToOne: false;
+            referencedRelation: "posts";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "comments_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      follow: {
+        Row: {
+          created_at: string;
+          follwer_id: string;
+          follwing: string;
+          id: string;
+        };
+        Insert: {
+          created_at?: string;
+          follwer_id: string;
+          follwing: string;
+          id?: string;
+        };
+        Update: {
+          created_at?: string;
+          follwer_id?: string;
+          follwing?: string;
+          id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "follow_follwer_id_fkey";
+            columns: ["follwer_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "follow_follwing_fkey";
+            columns: ["follwing"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      level: {
+        Row: {
+          id: string;
+          level: number | null;
+          required_exp: number | null;
+        };
+        Insert: {
+          id?: string;
+          level?: number | null;
+          required_exp?: number | null;
+        };
+        Update: {
+          id?: string;
+          level?: number | null;
+          required_exp?: number | null;
+        };
+        Relationships: [];
+      };
+      posts: {
+        Row: {
+          adopted_comment_id: string | null;
+          category_id: string;
+          content: string | null;
+          created_at: string;
+          id: string;
+          post_image: string | null;
+          title: string;
+          user_id: string;
+        };
+        Insert: {
+          adopted_comment_id?: string | null;
+          category_id: string;
+          content?: string | null;
+          created_at?: string;
+          id?: string;
+          post_image?: string | null;
+          title: string;
+          user_id: string;
+        };
+        Update: {
+          adopted_comment_id?: string | null;
+          category_id?: string;
+          content?: string | null;
+          created_at?: string;
+          id?: string;
+          post_image?: string | null;
+          title?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "posts_adopted_comment_id_fkey";
+            columns: ["adopted_comment_id"];
+            isOneToOne: false;
+            referencedRelation: "comments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "posts_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "category";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "posts_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      profiles: {
+        Row: {
+          avartar_image: string | null;
+          bio: string | null;
+          created_at: string;
+          email: string;
+          exp: number | null;
+          id: string;
+          level: number | null;
+          name: string;
+          phone_number: string | null;
+        };
+        Insert: {
+          avartar_image?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          email: string;
+          exp?: number | null;
+          id: string;
+          level?: number | null;
+          name: string;
+          phone_number?: string | null;
+        };
+        Update: {
+          avartar_image?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          email?: string;
+          exp?: number | null;
+          id?: string;
+          level?: number | null;
+          name?: string;
+          phone_number?: string | null;
+        };
+        Relationships: [];
+      };
+      user_badge: {
+        Row: {
+          achieve_date: string;
+          badge_id: string;
+          id: string;
+          user_id: string;
+        };
+        Insert: {
+          achieve_date?: string;
+          badge_id: string;
+          id?: string;
+          user_id: string;
+        };
+        Update: {
+          achieve_date?: string;
+          badge_id?: string;
+          id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "user_badge_badge_id_fkey";
+            columns: ["badge_id"];
+            isOneToOne: false;
+            referencedRelation: "badge";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "user_badge_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const;


### PR DESCRIPTION
## 📖 개요

- 카테고리 데이터 supabase에서 불러와 연동했습니다
- 카테고리 클릭시 해당되는 경로로 라우팅됩니다

## ✅ 관련 이슈

- Close #55

## 🛠️ 상세 작업 내용

- [x] supabase의 카테고리 데이터 연동
- [x] 카테고리별 라우팅

## ⚠️ 주의 사항 
- category 데이터 타입 지정을 위해 `utils/supabase` 폴더에 `supabase.ts` 파일 추가했습니다. 테이블들에 변동사항 있을 시 덮어씌워주시면 될 것 같습니다.
- next/image 보안 정책 관련 에러 발생해서 `next.config.js` 파일의 images.domains 배열에 supabase 프로젝트 도메인을 추가했습니다.
- 

## 📸 스크린샷

- 아이콘 hover시 배경 불투명, 어떤 카테고리인지 텍스트 노출
<img width="86" height="73" alt="image" src="https://github.com/user-attachments/assets/8a122310-48f9-42f9-a50b-d228e8f6585d" />

- 선택 시 main color로 border
<img width="73" height="69" alt="image" src="https://github.com/user-attachments/assets/5b4ee6f8-50b2-4f80-9397-bc8ac5380c17" />