### PR TITLE
feat: comment ui 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.80.0",
         "class-variance-authority": "^0.7.1",
+        "dayjs": "^1.11.19",
         "lucide-react": "^0.552.0",
         "next": "16.0.1",
         "react": "19.2.0",
@@ -2984,6 +2985,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.80.0",
     "class-variance-authority": "^0.7.1",
+    "dayjs": "^1.11.19",
     "lucide-react": "^0.552.0",
     "next": "16.0.1",
     "react": "19.2.0",

--- a/src/app/posts/[category]/layout.tsx
+++ b/src/app/posts/[category]/layout.tsx
@@ -2,7 +2,7 @@ import PostSideBar from "@/components/post/PostSideBar";
 
 export default function PostsCategoryLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="posts-area flex w-full gap-6">
+    <div className="posts-area flex h-full w-full gap-6">
       <PostSideBar />
       {children}
     </div>

--- a/src/app/posts/[category]/post/[postId]/page.tsx
+++ b/src/app/posts/[category]/post/[postId]/page.tsx
@@ -1,3 +1,4 @@
+import { twMerge } from "tailwind-merge";
 import MessageBubble from "@/components/comment/MessageBubble";
 import ResponsiveContainer from "@/components/common/ResponsiveContainer";
 import PostCard from "@/components/post/PostCard";
@@ -23,19 +24,26 @@ export default async function PostPage({ params }: { params: Promise<{ postId: s
   // const commentDataSample = null;
   return (
     <>
-      <ResponsiveContainer className="bg-bg-sub w-full overflow-hidden max-sm:border-none">
+      <ResponsiveContainer className="bg-bg-sub flex w-full flex-col overflow-hidden max-sm:border-none">
         <PostCard
           userName="나"
           title="이거 썸 맞나요?"
           content="이거 썸 맞나요?"
           className="bg-bg-main rounded-t-none border-t-0 border-r-0 border-l-0"
         />
-        <div className="px-6 py-5">
-          {commentDataSample ? (
-            commentDataSample.map(comment => <MessageBubble key={comment.id} data={comment} />)
-          ) : (
-            <p className="text-text-sub text-center text-sm">등록된 댓글이 없습니다.</p>
-          )}
+        <div className="flex h-full flex-col justify-between px-6 py-5">
+          <div className={twMerge("comments flex h-full flex-col", !commentDataSample && "justify-center")}>
+            {" "}
+            {commentDataSample ? (
+              commentDataSample.map(comment => <MessageBubble key={comment.id} data={comment} />)
+            ) : (
+              <p className="text-text-sub text-center text-sm">등록된 댓글이 없습니다.</p>
+            )}
+          </div>
+          <div className="comment-input-container bg-bg-main mt-5 flex items-center rounded-lg px-5 py-4">
+            <input type="text" name="" id="" className="bg-bg-sub mr-3 flex-3/4 rounded-sm px-2 py-1 outline-0" />
+            <button className="bg-main cursor-pointer rounded-sm px-3 py-1.5 text-xs text-white">보내기</button>
+          </div>
         </div>
       </ResponsiveContainer>
     </>

--- a/src/app/posts/layout.tsx
+++ b/src/app/posts/layout.tsx
@@ -11,7 +11,7 @@ export default async function PostsLayout({ children }: { children: React.ReactN
         <div className="max-sm:hidden">
           <Category categorys={data} />
         </div>
-        <div>{children}</div>
+        <div className="h-full">{children}</div>
       </div>
     );
   } else return null;

--- a/src/components/comment/MessageBubble.tsx
+++ b/src/components/comment/MessageBubble.tsx
@@ -64,7 +64,7 @@ export default function MessageBubble({ data }: { data: CommentType }) {
               <Badge text="연애프로 패널급" size="xs" className="bg-pink-600 px-1 text-white" />
             </div>
           </div>
-          <div className="flex items-end">
+          <div className="flex items-end gap-2">
             <div className={TextVariants({ isMine })}>
               <p>{content}</p>
             </div>

--- a/src/components/post/PostCardButton.tsx
+++ b/src/components/post/PostCardButton.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { cva, VariantProps } from "class-variance-authority";
+import dayjs from "dayjs";
+import "dayjs/locale/ko";
+import relativeTime from "dayjs/plugin/relativeTime";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
+import { PostType } from "@/types";
 import PostCardBookMark from "./PostCardBookMark";
+import { postCardSampleDataType } from "./PostSideBar";
 import Badge from "../common/Badge";
 
 const containerVariants = cva(
@@ -23,64 +28,59 @@ const containerVariants = cva(
   }
 );
 
-const userTextVariants = cva("post-card-btn_user flex justify-start", {
+const userTextVariants = cva("post-card-btn_user flex justify-start items-center", {
   variants: {
     device: {
       pc: "text-xs",
       mobile: "text-[8px]",
     },
   },
+  defaultVariants: {
+    device: "pc",
+  },
 });
 
-const titleVariants = cva("post-card-btn_title", {
+const titleVariants = cva("post-card-btn_title font-bold", {
   variants: {
     device: {
       pc: "text-base",
       mobile: "text-xs",
     },
   },
+  defaultVariants: {
+    device: "pc",
+  },
 });
 
 interface PostCardButtonProps extends VariantProps<typeof containerVariants> {
-  categoryId: string;
-  postId: string;
-  userName: string;
-  title: string;
-  date: string;
+  data: postCardSampleDataType;
   className?: string;
 }
 
-export default function PostCardButton({
-  device,
-  categoryId,
-  postId,
-  userName,
-  title,
-  date,
-  className,
-}: PostCardButtonProps) {
+export default function PostCardButton({ device, data, className }: PostCardButtonProps) {
   const [isClicked, setIsClicked] = useState(false);
+  const { id, createdAt, name, title, categoryName, categoryType } = data;
+  dayjs.extend(relativeTime);
+  dayjs.locale("ko");
 
   return (
-    <>
-      <Link
-        href={`/posts/${categoryId}/post/${postId}`}
-        className={twMerge(containerVariants({ device }), className, isClicked && "bg-main-50")}
-        onClick={() => setIsClicked(prev => !prev)}
-      >
-        <div className="post-card-btn_info space-y-2.5">
-          <PostCardBookMark />
-          <div className={userTextVariants({ device })}>
-            <span className="mr-2">{userName}</span>
-            <span className="text-text-light">{date}</span>
-          </div>
-          <p className={titleVariants({ device })}>{title}</p>
-          <Badge size="xs" text="카테고리" className="bg-rose-400 text-white" />
+    <Link
+      href={`/posts/${categoryType}/post/${id}`}
+      className={twMerge(containerVariants({ device }), className, isClicked && "bg-main-50")}
+      onClick={() => setIsClicked(prev => !prev)}
+    >
+      <div className="post-card-btn_info space-y-2.5">
+        <PostCardBookMark />
+        <div className={userTextVariants({ device })}>
+          <span className="mr-2">{name}</span>
+          <span className="text-text-light">{dayjs(createdAt).fromNow()}</span>
         </div>
-        <div className="post-card-btn_detail-btn text-text-sub my-auto w-4.5">
-          <ChevronRight size={18} />
-        </div>
-      </Link>
-    </>
+        <p className={titleVariants({ device })}>{title}</p>
+        <Badge size="xs" text={categoryName} className="bg-rose-400 text-white" />
+      </div>
+      <div className="post-card-btn_detail-btn text-text-sub my-auto w-4.5">
+        <ChevronRight size={18} />
+      </div>
+    </Link>
   );
 }


### PR DESCRIPTION
## 📖 개요

- post의 comment 부분 ui 완성했습니다. 

## ✅ 관련 이슈

- Close #56

## 🛠️ 상세 작업 내용

- [x] comment 영역 input 컴포넌트 ui 구현
- [x] post card button의 date 포맷팅 (~일 전)

## ⚠️ 주의 사항

- date 포맷팅을 위해 day.js 패키지 설치했습니다.

## 📸 스크린샷

<img width="523" height="405" alt="image" src="https://github.com/user-attachments/assets/b28b5ddc-7c77-477e-82fc-8cf8778ea6fb" />
