### PR TITLE
feat: 리스폰시브 컨테이너, 프로필/뱃지 이미지 border 삭제, border 다크모드 적용

### DIFF
--- a/src/components/chart/ChartPie.tsx
+++ b/src/components/chart/ChartPie.tsx
@@ -35,7 +35,7 @@ export default function ChartPie({
               innerRadius={`${innerRadius}%`}
               outerRadius="100%"
               paddingAngle={2}
-              stroke="#fff"
+              stroke="none"
             >
               {stats.map((data, index) => {
                 const fillColor = categoryColor[data.name];
@@ -53,7 +53,7 @@ export default function ChartPie({
           </PieChart>
         </RsponsiveContain>
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
-          <p className="text-xs text-gray-500">총</p>
+          <p className="text-text-title text-xs">총</p>
           <p className="text-lg font-bold">
             {totalPosts}
             {labelEndText}

--- a/src/components/chart/PieChartKey.tsx
+++ b/src/components/chart/PieChartKey.tsx
@@ -15,7 +15,7 @@ export default function PieChartKey({
         return (
           <div key={index} className="flex items-center gap-1">
             <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: fillColor }}></span>
-            <span className="text-text-light">{data.name}</span>
+            <span className="text-text-sub">{data.name}</span>
           </div>
         );
       })}

--- a/src/components/chart/allRank/AdoptStatsComponent.tsx
+++ b/src/components/chart/allRank/AdoptStatsComponent.tsx
@@ -28,7 +28,13 @@ export default function AdoptStatsComponent({
                 barCategoryGap="25%"
                 margin={{ top: 10, right: 10, left: 10, bottom: 20 }}
               >
-                <XAxis dataKey="name" tick={{ fill: "#555", fontSize: 14 }} axisLine={false} tickLine={false} />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 15 }}
+                  className="text-text-title"
+                  axisLine={false}
+                  tickLine={false}
+                />
                 <Tooltip
                   cursor={false}
                   contentStyle={{

--- a/src/components/chart/allRank/AllRankCard.tsx
+++ b/src/components/chart/allRank/AllRankCard.tsx
@@ -13,7 +13,7 @@ export default function AllRankCard({ category, title }: { category: AllStatsCar
           </span>{" "}
           {title}
         </div>
-        <div className="text-2xl text-black">{category.count}</div>
+        <div className="text-text-title text-2xl">{category.count}</div>
         <div className="text-text-title text-xs">{category.percent}%</div>
       </div>
       <div className="flex w-full justify-end">

--- a/src/components/chart/allRank/WeekCommentCard.tsx
+++ b/src/components/chart/allRank/WeekCommentCard.tsx
@@ -7,14 +7,9 @@ import BaseImage from "@/components/common/image/BaseImage";
 export default function WeekCommentCard({ comment }: { comment: weekCommentDataType }) {
   const router = useRouter();
   return (
-    <div className="relative flex w-full gap-3 rounded-lg border border-gray-300 px-4 py-5">
+    <div className="border-border-sub relative flex w-full gap-3 rounded-lg border px-4 py-5">
       <div className="flex flex-col items-center justify-center gap-0.5">
-        <BaseImage
-          src={comment.avatar_image}
-          rounded="lg"
-          alt="profile_img"
-          className="h-12 w-12 border border-gray-200"
-        />
+        <BaseImage src={comment.avatar_image} rounded="lg" alt="profile_img" className="h-12 w-12" />
         <div className="w-12 truncate text-center text-xs">{comment.name}</div>
       </div>
       <div className="mt-1 flex flex-col gap-0.5 pt-1">

--- a/src/components/chart/allRank/WeekPostCard.tsx
+++ b/src/components/chart/allRank/WeekPostCard.tsx
@@ -13,7 +13,7 @@ export default function WeekPostCard({ post }: { post: WeekPostDataType }) {
 
   return (
     <div
-      className="col-span-1 w-full cursor-pointer rounded-lg border border-gray-200 p-1 transition hover:scale-101"
+      className="border-border-main col-span-1 w-full cursor-pointer rounded-lg border p-1 transition hover:scale-101"
       onClick={() => router.push(`/posts/${post.category_type}/post/${post.post_id}`)}
     >
       <BaseImage src={image} alt="post_img" className="h-[250px] max-h-[200px] w-full" />
@@ -24,7 +24,7 @@ export default function WeekPostCard({ post }: { post: WeekPostDataType }) {
           <Badge
             text={post.category_name}
             size={"sm"}
-            className="text-white"
+            className="text-text-title"
             style={{ backgroundColor: categoryColor[post.category_name] }}
           />
         </div>

--- a/src/components/common/ResponsiveContainer.tsx
+++ b/src/components/common/ResponsiveContainer.tsx
@@ -9,7 +9,7 @@ export default function ResponsiveContainer({ className, children }: ResponsiveC
   return (
     <div
       className={twMerge(
-        "bg-bg-main rounded-md border border-gray-200 sm:rounded-lg md:rounded-xl lg:rounded-[18px] xl:rounded-3xl",
+        "bg-bg-main border-border-main rounded-md border sm:rounded-lg md:rounded-xl lg:rounded-[18px] xl:rounded-3xl",
         className
       )}
     >

--- a/src/components/common/image/BaseImage.tsx
+++ b/src/components/common/image/BaseImage.tsx
@@ -15,7 +15,7 @@ interface BaseImageProps {
   className?: string;
 }
 
-const BaseImageVariants = cva("relative overflow-hidden", {
+const BaseImageVariants = cva("relative overflow-hidden border-none", {
   variants: {
     rounded: {
       full: "rounded-full",

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -16,6 +16,8 @@
   /* 기본 테마(라이트 모드) 색상 정의 */
   --color-bg-main: #ffffff;
   --color-bg-sub: #f0f2f5;
+  --color-border-main: #e5e7eb;
+  --color-border-sub: #d1d5dc;
   --color-text-title: #0f172b;
   --color-text-content: #1d293d;
   --color-text-sub: #4a5565;
@@ -26,6 +28,8 @@
 .dark {
   --color-bg-main: #121212;
   --color-bg-sub: #202225;
+  --color-border-main: #374151;
+  --color-border-sub: #4b5563;
   --color-text-title: #f1f5ff;
   --color-text-content: #e2e8f5;
   --color-text-sub: #a8b1c1;


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 리스폰시브 컨테이너, 프로필/뱃지, 베이스 이미지 border 다크모드 적용
- 랭크 다른 페이지는 추후 적용 예정

## ✅ 관련 이슈

- Close #145 
