### PR TITLE
fix: 댓글 채널 모든 게시물에 적용되던 문제 수정

### DIFF
--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -27,35 +27,39 @@ export default function CommentList({
   useEffect(() => {
     const channel = supabase
       .channel(`comments-room-${postId}`)
-      .on("postgres_changes", { event: "*", schema: "public", table: "comments" }, payload => {
-        if (payload.eventType === "INSERT") {
-          const getComment = async (commentId: string) => {
-            const { data, error } = await supabase
-              .rpc("get_detail_comment", {
-                p_comment_id: commentId,
-              })
-              .select();
-            if (!error) {
-              setComments(prev => [...prev, data[0]]);
-            }
-          };
-          getComment(payload.new.id);
-        } else if (payload.eventType === "DELETE") {
-          setComments(prev => prev.filter(c => c.id !== payload.old.id));
-        } else if (payload.eventType === "UPDATE") {
-          const getComment = async (commentId: string) => {
-            const { data, error } = await supabase
-              .rpc("get_detail_comment", {
-                p_comment_id: commentId,
-              })
-              .select();
-            if (!error) {
-              setComments(prev => prev.map(c => (c.id === payload.new.id ? data[0] : c)));
-            }
-          };
-          getComment(payload.new.id);
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "comments", filter: `post_id=eq.${postId}` },
+        payload => {
+          if (payload.eventType === "INSERT") {
+            const getComment = async (commentId: string) => {
+              const { data, error } = await supabase
+                .rpc("get_detail_comment", {
+                  p_comment_id: commentId,
+                })
+                .select();
+              if (!error) {
+                setComments(prev => [...prev, data[0]]);
+              }
+            };
+            getComment(payload.new.id);
+          } else if (payload.eventType === "DELETE") {
+            setComments(prev => prev.filter(c => c.id !== payload.old.id));
+          } else if (payload.eventType === "UPDATE") {
+            const getComment = async (commentId: string) => {
+              const { data, error } = await supabase
+                .rpc("get_detail_comment", {
+                  p_comment_id: commentId,
+                })
+                .select();
+              if (!error) {
+                setComments(prev => prev.map(c => (c.id === payload.new.id ? data[0] : c)));
+              }
+            };
+            getComment(payload.new.id);
+          }
         }
-      })
+      )
       .subscribe();
 
     return () => {


### PR DESCRIPTION
## 📖 개요

- 댓글 채널 모든 게시물에 적용되던 문제 → 채널에 post id로 필터 걸어서 해결했습니다

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 댓글 채널 모든 게시물에 적용되는 문제 수정