### PR TITLE
fix: rank page UI data restructure

### DIFF
--- a/src/components/chart/ChartFillPie.tsx
+++ b/src/components/chart/ChartFillPie.tsx
@@ -44,7 +44,7 @@ const renderLabel = ({
 
 export default function ChartFillPie({ stats }: { stats: BagdeCountType[] }) {
   return (
-    <div className="relative h-[120px] w-[120px] min-w-0">
+    <div className="relative h-full min-h-[120px] w-full min-w-0">
       <ResponsiveContainer width="100%" height="100%">
         <PieChart width={120} height={120}>
           <Pie

--- a/src/components/chart/ChartFillPie.tsx
+++ b/src/components/chart/ChartFillPie.tsx
@@ -2,7 +2,14 @@
 
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
-const DEFAULT_COLORS = ["#FAF3C0", "#E8E9EB", "#E5C1A3", "#C3D3E1", "#F8D8B3"];
+const DEFAULT_COLORS = [
+  "#E3F2FD", // 부드러운 베이비 블루
+  "#E8F5E9", // 소프트 민트 그린
+  "#FFF3E0", // 연살구 오렌지
+  "#FCE4EC", // 부드러운 핑크
+  "#EDE7F6", // 소프트 라벤더
+  "#F3E5F5", // 부드러운 바이올렛 로즈
+];
 
 const RADIAN = Math.PI / 180;
 const renderLabel = ({
@@ -29,7 +36,7 @@ const renderLabel = ({
   const y = cyNum + radius * Math.sin(-midAngle * RADIAN);
 
   return (
-    <text x={x} y={y} fill="#333" textAnchor="middle" dominantBaseline="central" fontSize={12} fontWeight={700}>
+    <text x={x} y={y} fill="#333" textAnchor="middle" dominantBaseline="central" fontSize={11} fontWeight={700}>
       {`${((percent ?? 0) * 100).toFixed(0)}%`}
     </text>
   );
@@ -37,9 +44,9 @@ const renderLabel = ({
 
 export default function ChartFillPie({ stats }: { stats: BagdeCountType[] }) {
   return (
-    <div className="relative h-[130px] w-[130px] min-w-0">
+    <div className="relative h-[120px] w-[120px] min-w-0">
       <ResponsiveContainer width="100%" height="100%">
-        <PieChart width={130} height={130}>
+        <PieChart width={120} height={120}>
           <Pie
             data={stats}
             dataKey="achieved_count"
@@ -50,18 +57,18 @@ export default function ChartFillPie({ stats }: { stats: BagdeCountType[] }) {
             labelLine={false}
             label={renderLabel}
             paddingAngle={2}
-            stroke="#fff"
+            stroke="none"
             isAnimationActive
           >
             {stats.map((_, index) => {
               const fillColor = DEFAULT_COLORS[index % DEFAULT_COLORS.length];
-              return <Cell key={`cell-${index}`} fill={fillColor} />;
+              return <Cell key={`cell-${index}`} fill={fillColor} style={{ outline: "none" }} className="opacity-85" />;
             })}
           </Pie>
 
           <Tooltip
             contentStyle={{
-              borderRadius: "8px",
+              borderRadius: "10px",
               backgroundColor: "#fff",
               border: "1px solid #ddd",
             }}

--- a/src/components/chart/ChartPie.tsx
+++ b/src/components/chart/ChartPie.tsx
@@ -22,7 +22,7 @@ export default function ChartPie({
   return (
     <div className="h-fit min-w-[180px]">
       <div className="relative h-full min-h-[100px] w-full min-w-0">
-        <RsponsiveContain width="100%" height={height}>
+        <RsponsiveContain width="100%" height={height} className="pointer-events-none">
           <PieChart>
             <Pie
               data={stats}
@@ -39,7 +39,14 @@ export default function ChartPie({
             >
               {stats.map((data, index) => {
                 const fillColor = categoryColor[data.name];
-                return <Cell key={`cell-${index}`} fill={fillColor} />;
+                return (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={fillColor}
+                    style={{ outline: "none" }}
+                    className="pointer-events-auto"
+                  />
+                );
               })}
             </Pie>
             <Tooltip

--- a/src/components/chart/ChartPie.tsx
+++ b/src/components/chart/ChartPie.tsx
@@ -8,6 +8,7 @@ export default function ChartPie({
   height = 250,
   innerRadius = 73,
   labelEndText = "개",
+  total_point,
 }: {
   stats: {
     name: string;
@@ -16,6 +17,7 @@ export default function ChartPie({
   height?: number;
   innerRadius?: number;
   labelEndText?: string;
+  total_point?: number;
 }) {
   const totalPosts = stats.reduce((acc, cur) => acc + cur.value, 0);
 
@@ -61,8 +63,8 @@ export default function ChartPie({
         </RsponsiveContain>
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
           <p className="text-text-title text-xs">총</p>
-          <p className="text-lg font-bold">
-            {totalPosts}
+          <p className="text-text-sub text-lg font-bold">
+            {total_point ? total_point : totalPosts}
             {labelEndText}
           </p>
         </div>

--- a/src/components/chart/ProgressBar.tsx
+++ b/src/components/chart/ProgressBar.tsx
@@ -20,9 +20,9 @@ export default function ProgressBar({ percent, count, color, className }: Progre
   return (
     <div
       className={twMerge(
-        "flex h-4 w-full overflow-hidden rounded-full bg-gray-200 md:w-11/12",
+        "bg-border-sub flex h-4 w-full overflow-hidden rounded-full md:w-11/12",
         className,
-        !count && "bg-gray-300"
+        !count && "bg-border-main"
       )}
       role="progressbar"
       aria-valuenow={percentages}

--- a/src/components/chart/allRank/AdoptStatsComponent.tsx
+++ b/src/components/chart/allRank/AdoptStatsComponent.tsx
@@ -19,40 +19,47 @@ export default function AdoptStatsComponent({
       {
         <div className="flex flex-col">
           <ChartCardTtile title="채택" subTitle="훈수별 채택" />
-          <div className="mx-auto h-[400px] w-11/12">
-            <RsponsiveContain width="100%" height={400}>
-              <BarChart
-                data={stats}
-                width={100}
-                height={100}
-                barCategoryGap="25%"
-                margin={{ top: 10, right: 10, left: 10, bottom: 20 }}
-              >
-                <XAxis
-                  dataKey="name"
-                  tick={{ fontSize: 15 }}
-                  className="text-text-title"
-                  axisLine={false}
-                  tickLine={false}
-                />
-                <Tooltip
-                  cursor={false}
-                  contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #e5e7eb",
-                    borderRadius: "8px",
-                    fontSize: "13px",
-                  }}
-                />
-                <Bar dataKey="채택" stackId="a" radius={[0, 0, 8, 8]} activeBar={false}>
-                  {stats.map((data, i) => {
-                    const fillColor = categoryColor[data.name] ?? "#CCCCCC";
-                    return <Cell key={`cell-${i}`} fill={fillColor} />;
-                  })}
-                </Bar>
-                <Bar dataKey="훈수" stackId="a" fill="#E2E2E2" radius={[8, 8, 0, 0]} activeBar={false} />
-              </BarChart>
-            </RsponsiveContain>
+
+          {/* 스크롤 컨테이너 */}
+          <div className="mx-auto flex w-full items-center justify-center overflow-x-auto">
+            {/* 차트 자체 폭 고정 */}
+            <div className="mx-auto h-[400px] min-w-[1000px]">
+              <RsponsiveContain width={1000} height={400}>
+                <BarChart
+                  data={stats}
+                  width={1000}
+                  height={400}
+                  barCategoryGap="25%"
+                  margin={{ top: 10, right: 10, left: 10, bottom: 20 }}
+                >
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 15 }}
+                    className="text-text-title"
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <Tooltip
+                    cursor={false}
+                    contentStyle={{
+                      backgroundColor: "white",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "8px",
+                      fontSize: "13px",
+                    }}
+                  />
+
+                  <Bar dataKey="채택" stackId="a" radius={[0, 0, 8, 8]} activeBar={false}>
+                    {stats.map((data, i) => {
+                      const fillColor = categoryColor[data.name] ?? "#CCCCCC";
+                      return <Cell key={`cell-${i}`} fill={fillColor} />;
+                    })}
+                  </Bar>
+
+                  <Bar dataKey="훈수" stackId="a" fill="#E2E2E2" radius={[8, 8, 0, 0]} activeBar={false} />
+                </BarChart>
+              </RsponsiveContain>
+            </div>
           </div>
         </div>
       }

--- a/src/components/chart/allRank/WeekPostCard.tsx
+++ b/src/components/chart/allRank/WeekPostCard.tsx
@@ -24,7 +24,7 @@ export default function WeekPostCard({ post }: { post: WeekPostDataType }) {
           <Badge
             text={post.category_name}
             size={"sm"}
-            className="text-text-title"
+            className="text-bg-main font-semibold"
             style={{ backgroundColor: categoryColor[post.category_name] }}
           />
         </div>

--- a/src/components/chart/categoryRank/AdoptRatioChart.tsx
+++ b/src/components/chart/categoryRank/AdoptRatioChart.tsx
@@ -45,7 +45,7 @@ export default function AdoptRatioChart({ label, percentage, color = "#007F5F" }
           />
         </RadialBarChart>
 
-        <span className="absolute inset-0 flex items-center justify-center text-[15px] font-semibold text-gray-800">
+        <span className="text-text-sub absolute inset-0 flex items-center justify-center text-[15px] font-semibold">
           {percentage}%
         </span>
       </div>

--- a/src/components/chart/categoryRank/CategoryRankCard.tsx
+++ b/src/components/chart/categoryRank/CategoryRankCard.tsx
@@ -91,9 +91,9 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
             <AdoptRatioChart label="사용자별 뱃지" percentage={getBadgePercent} color={color} />
           </div>
         </div>
-        <div className="flex flex-col gap-1.5">
+        <div className="flex min-w-[150px] flex-col gap-1.5">
           <div className="text-text-title text-[15px] font-semibold">업적별 뱃지</div>
-          <div className="h-[100px]">
+          <div className="h-[120px]">
             {!badgeCountStat && (
               <Badge size="md" className="bg-text-sub text-bg-main px-2 py-1 font-semibold" text="지표가 부족합니다" />
             )}

--- a/src/components/chart/categoryRank/CategoryRankCard.tsx
+++ b/src/components/chart/categoryRank/CategoryRankCard.tsx
@@ -21,12 +21,12 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
         <div className="flex w-full max-w-[200px] flex-col gap-2">
           <div className="flex gap-8">
             <div className="flex flex-col gap-1">
-              <div className="text-text-title mb-0.5 text-sm font-semibold">총 Exp</div>
-              <div className="text-text-sub text-lg">{stats.total_point?.toLocaleString()}P</div>
+              <div className="text-text-title mb-0.5 text-[15px] font-semibold">총 Exp</div>
+              <div className="text-text-sub text-[16px]">{stats.total_point?.toLocaleString()}P</div>
             </div>
             <div className="flex flex-col gap-1">
-              <div className="text-text-title mb-0.5 text-sm font-semibold">평균 훈수</div>
-              <div className="text-text-sub text-lg">{stats.avg_comments} 개</div>
+              <div className="text-text-title mb-0.5 text-[15px] font-semibold">평균 훈수</div>
+              <div className="text-text-sub text-[16px]">{stats.avg_comments} 개</div>
             </div>
           </div>
         </div>
@@ -41,7 +41,7 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
                 <Badge
                   key={index}
                   size="md"
-                  className="px-2 py-1 text-white"
+                  className="text-bg-main px-2 py-1 font-semibold"
                   text={keyword}
                   style={{ backgroundColor: color }}
                 />
@@ -50,7 +50,7 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
         </div>
       </div>
 
-      <div className="my-6 mt-7 border-t border-gray-100" />
+      <div className="border-border-sub my-6 mt-7 border-t" />
 
       <div className="ml-1 flex w-full flex-col gap-2">
         <div className="text-text-title text-[15px] font-semibold">랭킹 TOP3</div>
@@ -74,14 +74,14 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
                   size="md"
                   className="border-none"
                 />
-                <span className="text-text-content font-semibol text-xs">{user.user_name}</span>
+                <span className="text-xs font-semibold text-black">{user.user_name}</span>
               </div>
             );
           })}
         </div>
       </div>
 
-      <div className="my-6 mt-7 border-t border-gray-100" />
+      <div className="border-border-sub my-6 mt-7 border-t" />
 
       <div className="ml-1 flex w-full flex-wrap gap-8">
         <div className="flex w-full max-w-[250px] flex-col gap-3">
@@ -91,11 +91,11 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
             <AdoptRatioChart label="사용자별 뱃지" percentage={getBadgePercent} color={color} />
           </div>
         </div>
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
           <div className="text-text-title text-[15px] font-semibold">업적별 뱃지</div>
-          <div className="h-[130px]">
+          <div className="h-[100px]">
             {!badgeCountStat && (
-              <Badge size="md" className="bg-text-sub px-2 py-1 text-white" text="지표가 부족합니다" />
+              <Badge size="md" className="bg-text-sub text-bg-main px-2 py-1 font-semibold" text="지표가 부족합니다" />
             )}
             {!!badgeCountStat && <ChartFillPie stats={stats.badge_counts} />}
           </div>

--- a/src/components/chart/myRank/MyRankComponent.tsx
+++ b/src/components/chart/myRank/MyRankComponent.tsx
@@ -23,10 +23,7 @@ export default async function MyRankComponent({ user }: { user: User }) {
     const { category_name, posts_count, comments_count } = item;
     const categoryBadge = myBadgePoint.find(c => c.category_name, item.category_name);
     const total_point =
-      (posts_count || 1) *
-      (comments_count || 1) *
-      (categoryBadge?.badge_points ? categoryBadge?.badge_points * 0.01 : 1) *
-      10;
+      posts_count * 10 + comments_count * 10 + (categoryBadge?.badge_points ? categoryBadge?.badge_points * 0.01 : 0);
 
     return { total_point, category_name, posts_count, comments_count, badge_point: categoryBadge?.badge_points };
   });

--- a/src/components/chart/myRank/MyTypeComponent.tsx
+++ b/src/components/chart/myRank/MyTypeComponent.tsx
@@ -7,19 +7,21 @@ import PieChartKey from "../PieChartKey";
 
 export default function MyTypeComponent({ stats }: { stats: MyTypeDataType[] }) {
   const chartData = stats.slice(0, 2).map(item => ({ name: item.category_name, value: item.total_point }));
+  const total_point = stats.reduce((acc, cur) => acc + cur.total_point, 0);
   return (
     <ResponsiveContainer className="min-h-0 w-full px-5 py-6">
       <ChartCardTtile title="유형" subTitle="총 합산 ( 게시글, 훈수, 뱃지 포인트 )" />
       <div className="max-h-100px gap mx-auto flex w-[95%] flex-col items-center justify-center gap-15 gap-y-10 md:flex-row">
         <div className="flex h-full w-[40%] flex-col gap-10 pt-5">
-          <ChartPie stats={chartData} innerRadius={78} height={200} labelEndText="점" />
+          <ChartPie stats={chartData} total_point={total_point} innerRadius={78} height={200} labelEndText="점" />
           <PieChartKey stats={chartData} />
         </div>
-        <ResponsiveContainer className="min-h-[265px] w-full min-w-[250px] bg-gray-50 p-5 md:w-[45%]">
+        <ResponsiveContainer className="bg-bg-main min-h-[265px] w-full min-w-[250px] p-5 md:w-[45%]">
           <div className="mb-6 flex flex-col gap-1">
             <span className="text-text-sub text-sm font-semibold">당신의 유형은?</span>
             <span className="text-text-light text-sm font-semibold">
-              <span className="text-[16px] text-black">{`${chartData[0].name} | ${chartData[1].name}`}</span> 입니다.
+              <span className="text-text-title text-[16px]">{`${chartData[0].name} | ${chartData[1].name}`}</span>{" "}
+              입니다.
             </span>
           </div>
           <div className="flex w-11/12 flex-wrap gap-6 gap-y-3">
@@ -30,7 +32,7 @@ export default function MyTypeComponent({ stats }: { stats: MyTypeDataType[] }) 
                   <Badge
                     text={category.category_name}
                     style={{ backgroundColor: color }}
-                    className="text-white"
+                    className="text-bg-main font-semibold"
                     size={"sm"}
                   />
                   <span className="text-text-title text-xs font-semibold">{`${category.total_point.toLocaleString()}P`}</span>

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -9,7 +9,11 @@
 }
 
 .recharts-surface,
-.recharts-wrapper {
+.recharts-wrapper,
+.recharts-responsive-container,
+.recharts-surface,
+.recharts-layer,
+.recharts-pie {
   outline: none !important;
 }
 

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -8,6 +8,11 @@
   --global-padding: 24px;
 }
 
+.recharts-surface,
+.recharts-wrapper {
+  outline: none !important;
+}
+
 @theme {
   /* 공통 색상 정의 */
   --color-main: #2b7fff;


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 랭크 페이지 전반적 UI, 다크모드 수정
- 내 랭크 총 포인트 재구성

## ✅ 관련 이슈

- Close #167 

## 🛠️ 상세 작업 내용

- [x] 차트 아웃라인 삭제
- [x] 다크모드
- [x] 총 포인트: 게시글 수 * 10 + 댓글 수 * 10 + 뱃지포인트*0.01 
