### PR TITLE
feat: 실시간 검색 기능 추가

### DIFF
--- a/src/components/search/ResultPosts.tsx
+++ b/src/components/search/ResultPosts.tsx
@@ -2,7 +2,7 @@
 
 import dayjs from "dayjs";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { PostWithProfile } from "@/types/search";
 import { categoryColor } from "@/utils/category";
@@ -17,14 +17,17 @@ export default function ResultPosts({
   textHighlight?: (text: string) => string | React.ReactElement[];
 }) {
   const router = useRouter();
+  const path = usePathname().split("/");
+  const pathType = path[1];
+
   const handleClick = (id: string, category?: string) => {
     router.push(`/posts/${category}/post/${id}`);
   };
 
-  if (!searchData || searchData.length === 0)
+  if (pathType === "user" && (!searchData || searchData.length === 0))
     return <p className="flex justify-center py-3 text-sm">첫 훈수 요청을 해보세요.</p>;
 
-  return searchData.map(post => (
+  return searchData?.map(post => (
     <div key={post.id} className={cardVariants()} onClick={() => handleClick(post.id, post.category?.type)}>
       <div className="flex flex-col gap-6 p-6">
         <div className="flex gap-2 text-xs">

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -11,19 +11,33 @@ export default function SearchBar({ searchType, isSearched, TopData }: SearchBar
   const route = useRouter();
   const [query, setQuery] = useState("");
   const queryChange = useSearchParams();
+  const q = queryChange.get("query") ?? "";
 
+  // 검색 버튼 - 제출로 인한 이동
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (!query.trim()) return;
 
-    route.push(`/search/${searchType}?query=${encodeURIComponent(query)}`);
+    if (!q) route.push(`/search/${searchType}?query=${encodeURIComponent(query)}`);
   };
 
   useEffect(() => {
-    const q = queryChange.get("query") ?? "";
     if (q !== query) setQuery(q);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryChange]);
+
+  // 실시간 이동
+  useEffect(() => {
+    if (!query.trim()) return;
+
+    if (q) {
+      const timer = setTimeout(() => {
+        route.replace(`/search/${searchType}?query=${encodeURIComponent(query)}`);
+      }, 500);
+
+      return () => clearTimeout(timer);
+    }
+  }, [query, route]);
 
   return (
     <>


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 실시간 검색 기능을 구현했습니다. 첫 화면에서는 추천 검색어 등의 UX 흐름을 방해하지 않도록 안 넣었고, 검색 결과 화면에서는 작동합니다~

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 메인 검색 페이지 제외 검색 결과 페이지 내에서 실시간 검색 기능을 추가
- [x] 마이페이지 게시글 없을 때 나오던 멘트가 검색 화면에서 나오지 않도록 조건 추가

## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->

## 👥 리뷰 확인 사항 (옵션)

<!-- 코드 리뷰 시에 특별히 확인해야 하는 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->

제가 해냄! 한 번 써보시고 보완사항 있음 말씀해주세용