### PR TITLE
feat: top3 유저 프로필 보기 추가

### DIFF
--- a/src/app/(public)/chart/category-rank/page.tsx
+++ b/src/app/(public)/chart/category-rank/page.tsx
@@ -1,5 +1,17 @@
 import CategoryRankComponent from "@/components/chart/categoryRank/CategoryRankComponent";
+import { createClient } from "@/utils/supabase/server";
 
-export default function page() {
-  return <CategoryRankComponent />;
+export default async function page() {
+  const supabase = await createClient();
+  const { data: statsData, error } = await supabase.rpc("get_category_full_statistics");
+
+  if (error) throw error;
+
+  const parsedData = statsData?.map(item => ({
+    ...item,
+    topusers: item.topusers ? (item.topusers as TopUserType[]) : [],
+    badge_counts: item.badge_counts ? (item.badge_counts as BagdeCountType[]) : [],
+  }));
+
+  return <CategoryRankComponent stats={parsedData} />;
 }

--- a/src/components/chart/categoryRank/CategoryRankCard.tsx
+++ b/src/components/chart/categoryRank/CategoryRankCard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
 import Badge from "@/components/common/Badge";
 import CircleProfileImage from "@/components/common/image/CircleProfileImage";
 import ResponsiveContainer from "@/components/common/ResponsiveContainer";
@@ -7,6 +10,8 @@ import AdoptRatioChart from "./AdoptRatioChart";
 import ChartFillPie from "../ChartFillPie";
 
 export default function CategoryRankCard({ stats }: { stats: categoryStatsType }) {
+  const router = useRouter();
+  const currentPath = usePathname();
   const color = categoryColor[stats.category_name];
   const adoptedPercent = stats.total_posts > 0 ? Math.round((stats.adopted_posts / stats.total_posts) * 100) : 0;
   const getBadgePercent = Math.round((stats.users_with_badge / stats.total_users) * 100);
@@ -17,8 +22,8 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
       <div className="mb-7.5 text-lg font-semibold" style={{ color }}>
         {stats.category_name}
       </div>
-      <div className="ml-1 flex w-full flex-wrap gap-6">
-        <div className="flex w-full max-w-[200px] flex-col gap-2">
+      <div className="ml-1 flex w-full flex-wrap gap-5">
+        <div className="flex w-full max-w-40 flex-col gap-2 md:max-w-[200px]">
           <div className="flex gap-8">
             <div className="flex flex-col gap-1">
               <div className="text-text-title mb-0.5 text-[15px] font-semibold">총 Exp</div>
@@ -65,6 +70,11 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
               <div
                 key={user.user_id}
                 className={`relative flex flex-col items-center justify-center gap-1 overflow-hidden rounded-xl p-2 py-2.5 font-semibold shadow-sm before:absolute before:inset-0 before:opacity-15 before:content-[''] ${metalClasses[index]} `}
+                onClick={() => {
+                  const next = new URLSearchParams();
+                  next.set("user", user.user_id);
+                  router.push(`${currentPath}?${next.toString()}`);
+                }}
               >
                 <CircleProfileImage
                   src={
@@ -83,7 +93,7 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
 
       <div className="border-border-sub my-6 mt-7 border-t" />
 
-      <div className="ml-1 flex w-full flex-wrap gap-8">
+      <div className="ml-1 flex w-full flex-wrap gap-5 md:gap-8">
         <div className="flex w-full max-w-[250px] flex-col gap-3">
           <div className="text-text-title text-[15px] font-semibold">지표</div>
           <div className="flex gap-3">
@@ -91,7 +101,7 @@ export default function CategoryRankCard({ stats }: { stats: categoryStatsType }
             <AdoptRatioChart label="사용자별 뱃지" percentage={getBadgePercent} color={color} />
           </div>
         </div>
-        <div className="flex min-w-[150px] flex-col gap-1.5">
+        <div className="flex min-w-[110px] flex-col gap-1.5 md:min-w-[120px]">
           <div className="text-text-title text-[15px] font-semibold">업적별 뱃지</div>
           <div className="h-[120px]">
             {!badgeCountStat && (

--- a/src/components/chart/categoryRank/CategoryRankComponent.tsx
+++ b/src/components/chart/categoryRank/CategoryRankComponent.tsx
@@ -1,23 +1,28 @@
-import { createClient } from "@/utils/supabase/server";
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { twMerge } from "tailwind-merge";
+import ProfileSlide from "@/components/user/ProfileSlide";
 import CategoryRankCard from "./CategoryRankCard";
 
-export default async function CategoryRankComponent() {
-  const supabase = await createClient();
-  const { data: statsData, error } = await supabase.rpc("get_category_full_statistics");
-
-  if (error) throw error;
-
-  const parsedData = statsData?.map(item => ({
-    ...item,
-    topusers: item.topusers ? (item.topusers as TopUserType[]) : [],
-    badge_counts: item.badge_counts ? (item.badge_counts as BagdeCountType[]) : [],
-  }));
-
+export default function CategoryRankComponent({ stats }: { stats: categoryStatsType[] }) {
+  const search = useSearchParams();
+  const user = search.get("user");
   return (
-    <div className="grid w-full grid-cols-1 gap-5 py-7 pt-0 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2">
-      {parsedData?.map(stats => (
-        <CategoryRankCard key={stats.category_id} stats={stats} />
-      ))}
+    <div>
+      <div
+        className={twMerge(
+          "grid w-full grid-cols-1 gap-5 py-7 pt-0 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2",
+          user && "hidden"
+        )}
+      >
+        {stats?.map(st => (
+          <CategoryRankCard key={st.category_id} stats={st} />
+        ))}
+      </div>
+      <div>
+        <ProfileSlide />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 카테고리별 랭킹 페이지에서 탑 유저의 정보 볼 수 있게

## ✅ 관련 이슈

- 이슈 없이 작업 했습니다

## 🛠️ 상세 작업 내용

- [x] page.tsx에서 데이터 뽑아서 전달하는 방식으로 변경
- [x] categoryrank 컴포넌트 클라이언트 컴포넌트 로 변경 후 user params 받기
- [x] profileSlide 컴포넌트 활용해서 탑 유저 프로필 보여주기  

