### PR TITLE
fix: 게시물 이미지 업로드 이미지 형식, 용량 에러 수정

### DIFF
--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -32,6 +32,18 @@ export default function PostForm({
 
     if (!file) return;
 
+    if (file.size > 1024 * 1024) {
+      Toast({ message: "1MB 이하의 이미지만 업로드 할 수 있습니다.", type: "ERROR" });
+      e.target.value = "";
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      Toast({ message: "이미지 파일만 업로드할 수 있습니다.", type: "ERROR" });
+      e.target.value = "";
+      return;
+    }
+
     const url = URL.createObjectURL(file);
 
     setPreview(url);


### PR DESCRIPTION
## 📖 개요

- 이미지 아닌 파일 업로드 시 에러 toast
- 1MB 이하 이미지만 업로드 가능하게 수정

## ✅ 관련 이슈

- Close #173 

## 🛠️ 상세 작업 내용

- [x] 이미지 아닌 파일 업로드 시 에러 toast
- [x] 1MB 이하 이미지만 업로드 가능하게 수정
